### PR TITLE
Build Travis only on master and include Hound config

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+fail_on_violations: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,11 @@ xcode_workspace: pilot.xcworkspace
 xcode_scheme: pilot
 xcode_sdk: iphonesimulator11.0
 
+# Use xcodebuild with xcpretty
 script: set -o pipefail && xcodebuild test -workspace pilot.xcworkspace -scheme pilot -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' | xcpretty
+
+# Restrict branch builds to master
+branches:
+  only:
+    - master
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
+<img align="left" src="https://github.com/SanctionCo/pilot-ios/blob/master/pilot/Assets.xcassets/AppIcon.appiconset/Icon-App-40x40%403x.png">
+
 # Pilot (iOS)
+[![Build Status](https://travis-ci.org/SanctionCo/pilot-ios.svg?branch=master)](https://travis-ci.org/SanctionCo/pilot-ios)
 ![Version](https://img.shields.io/badge/version-dev-7f8c8d.svg)
+[![License](https://img.shields.io/badge/license-MIT-FF7178.svg)](https://github.com/SanctionCo/pilot-ios/blob/master/LICENSE)
 
 Pilot is a social media management application. Upload a posts or media to Facebook, Twitter, and more all from the convenience of one app!
 


### PR DESCRIPTION
- Tell Travis to only build the master branch so that PRs only have one Travis build to complete.
- Introduce Hound for style checking
- Update README

Addresses #31.