### PR TITLE
Fix FaceID error/crash

### DIFF
--- a/pilot/Info.plist
+++ b/pilot/Info.plist
@@ -48,6 +48,8 @@
 	<string>$(PRODUCT_NAME) Need to access camera</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$(PRODUCT_NAME) Need to access photos</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Used to sign in to Pilot</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/pilot/LoginViewController.swift
+++ b/pilot/LoginViewController.swift
@@ -262,7 +262,6 @@ class LoginViewController: UIViewController {
 
     // Only set up if the user can use biometrics
     guard authenticationHelper.canUseBiometrics() else {
-      UserDefaults.standard.set(false, forKey: "biometrics")
       completion()
       return
     }

--- a/pilot/UserDefaults+Pilot.swift
+++ b/pilot/UserDefaults+Pilot.swift
@@ -10,6 +10,6 @@ import Foundation
 
 extension UserDefaults {
   func contains(key: String) -> Bool {
-    return UserDefaults.standard.object(forKey: key) != nil
+    return self.object(forKey: key) != nil
   }
 }


### PR DESCRIPTION
Quick PR to fix #68.

- Set NSFaceIDUsageDescription flag in `Info.plist`
- No longer set the `biometrics` user default if the user can't use biometrics. Reason for doing this is because it can cause confusion. If the user doesn't have biometrics set up on their device, opens Pilot, then goes and sets up biometrics on their device, then uses Pilot again, they may never know that they have the option to log in with biometrics. We want to present the option the first time they are able to use biometrics, so we should not set the UserDefault until they are presented the option.
- Fix (possible) bug with `UserDefaults` extension. Possible bug: if you call `contains(key:)` on an instance of `UserDefaults` that is not `UserDefaults.standard`, it would only look for if the key is contained in `UserDefaults.standard`. Now it will look on the object you call it on.